### PR TITLE
Fix: Remove invalid stylehint elements from sshterminal.ui

### DIFF
--- a/src/sshterminal.ui
+++ b/src/sshterminal.ui
@@ -38,7 +38,6 @@
       <font>
        <family>Monospace</family>
        <pointsize>10</pointsize>
-       <stylehint>TypeWriter</stylehint>
       </font>
      </property>
      <property name="styleSheet">
@@ -52,7 +51,6 @@
       <font>
        <family>Monospace</family>
        <pointsize>10</pointsize>
-       <stylehint>TypeWriter</stylehint>
       </font>
      </property>
      <property name="styleSheet">


### PR DESCRIPTION
- Removed <stylehint>TypeWriter</stylehint> elements that caused uic compilation errors
- Qt Designer UI compiler does not recognize stylehint as valid XML element
- Monospace font is still applied via <family>Monospace</family> element
- Fixes AutoUic subprocess error during build process