### PR TITLE
Fix: Resolve compilation errors in SFTPBrowser

### DIFF
--- a/src/sftpbrowser.cpp
+++ b/src/sftpbrowser.cpp
@@ -10,6 +10,7 @@
 #include <QHeaderView>
 #include <QFrame>
 #include <QDir>
+#include <QListWidgetItem>
 
 SFTPBrowser::SFTPBrowser(const ServerConfig &config, QWidget *parent)
     : QWidget(parent)
@@ -200,7 +201,7 @@ void SFTPBrowser::onLocalFileDoubleClicked(const QModelIndex &index)
     if (m_localModel->isDir(index)) {
         // Navigate to directory
         ui->localTreeView->setRootIndex(index);
-        m_localPathLabel->setText("Local Files - " + m_localModel->filePath(index));
+        ui->localPathLabel->setText("Local Files - " + m_localModel->filePath(index));
     }
 }
 

--- a/src/sftpbrowser.h
+++ b/src/sftpbrowser.h
@@ -16,6 +16,7 @@ class SFTPBrowser;
 class TransferQueueWidget;
 class QTreeView;
 class QListWidget;
+class QListWidgetItem;
 class QLabel;
 
 class SFTPBrowser : public QWidget


### PR DESCRIPTION
- Added missing QListWidgetItem forward declaration in sftpbrowser.h
- Added missing #include <QListWidgetItem> in sftpbrowser.cpp
- Fixed reference from m_localPathLabel to ui->localPathLabel
- Resolves compilation errors related to missing declarations and UI references