### PR TITLE
Fix include path for custom widget in UI file

### DIFF
--- a/qtissh.pro
+++ b/qtissh.pro
@@ -15,6 +15,9 @@ QT += core gui widgets
 CONFIG += c++17 release
 # CONFIG += debug
 
+# Include paths
+INCLUDEPATH += src
+
 # -------------------------------------------------
 # Source files, headers and UI
 # -------------------------------------------------


### PR DESCRIPTION
Added INCLUDEPATH += src to qtissh.pro to ensure the UI compiler can find the servertreewidget.h header when processing mainwindow.ui.

This resolves the compilation error:
'servertreewidget.h: No such file or directory'