### PR TITLE
Fix unused parameter warnings in sftpbrowser.cpp

### DIFF
--- a/src/sftpbrowser.cpp
+++ b/src/sftpbrowser.cpp
@@ -369,11 +369,13 @@ void TransferQueueWidget::onTransferRemoved(const QString &transferId)
 
 void TransferQueueWidget::onTransferProgressChanged(const QString &transferId, int percent)
 {
+    Q_UNUSED(percent)
     updateTransferItem(transferId);
 }
 
 void TransferQueueWidget::onTransferStatusChanged(const QString &transferId, TransferStatus status)
 {
+    Q_UNUSED(status)
     updateTransferItem(transferId);
 }
 


### PR DESCRIPTION
Added Q_UNUSED() macros for unused parameters in:
- TransferQueueWidget::onTransferProgressChanged() - percent parameter
- TransferQueueWidget::onTransferStatusChanged() - status parameter

These parameters are required by the signal-slot interface but not currently used in the implementation. Using Q_UNUSED() is the Qt standard way to suppress these compiler warnings.