### PR TITLE
Fix VT100 terminal compilation errors

### DIFF
--- a/src/terminalchar.h
+++ b/src/terminalchar.h
@@ -45,6 +45,11 @@ enum class TextAttribute : int {
 Q_DECLARE_FLAGS(TextAttributes, TextAttribute)
 Q_DECLARE_OPERATORS_FOR_FLAGS(TextAttributes)
 
+// Define bitwise NOT operator for TextAttribute
+inline TextAttributes operator~(TextAttribute attr) {
+    return static_cast<TextAttributes>(~static_cast<int>(attr));
+}
+
 /**
  * @brief Represents a single character in the terminal with its attributes
  */

--- a/src/vt100terminal.cpp
+++ b/src/vt100terminal.cpp
@@ -355,6 +355,8 @@ QRect VT100Terminal::getCharacterRect(int row, int column) const
 
 void VT100Terminal::drawCharacter(QPainter &painter, int row, int column, const TerminalChar &ch, const QRect &charRect)
 {
+    Q_UNUSED(row)
+    Q_UNUSED(column)
     // Get colors
     QColor fg = getCharacterColor(ch.foregroundColor, true);
     QColor bg = getCharacterColor(ch.backgroundColor, false);
@@ -802,7 +804,6 @@ QByteArray VT100Terminal::keyEventToSequence(QKeyEvent *event)
 }
 
 // Placeholder implementations for remaining methods
-bool VT100Terminal::hasSelection() const { return m_hasSelection; }
 QString VT100Terminal::selectedText() const { return QString(); }
 void VT100Terminal::clearSelection() { m_hasSelection = false; update(); }
 void VT100Terminal::selectAll() { /* Implementation */ }


### PR DESCRIPTION
- Add bitwise NOT operator for TextAttribute enum to support &= ~attribute operations
- Add Q_UNUSED macros for unused parameters in drawCharacter method
- Remove duplicate hasSelection() method definition (already defined inline in header)

These fixes resolve all compilation errors in the VT100 terminal implementation.