### PR TITLE
Fix compilation error: Add Qt network module

### DIFF
--- a/qtissh.pro
+++ b/qtissh.pro
@@ -11,7 +11,7 @@ VERSION = v0.1.4
 # -------------------------------------------------
 # Basic configuration
 # -------------------------------------------------
-QT += core gui widgets
+QT += core gui widgets network
 CONFIG += c++17 release
 # CONFIG += debug
 


### PR DESCRIPTION
- Add 'network' to QT modules in qtissh.pro
- Required for QTcpSocket used in TerminalSession for Telnet connections
- Resolves fatal error: QTcpSocket: No such file or directory