### PR TITLE
Fix pure virtual function calls and warnings

### DIFF
--- a/src/maintabwindow.cpp
+++ b/src/maintabwindow.cpp
@@ -668,6 +668,7 @@ void MainTabWindow::onSessionStateChanged(SessionState newState, SessionState ol
 
 void MainTabWindow::onSessionNameChanged(const QString &newName)
 {
+    Q_UNUSED(newName)
     Session *session = qobject_cast<Session*>(sender());
     if (session) {
         updateSessionTab(session);

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -16,10 +16,8 @@ Session::Session(SessionType type, QObject *parent)
 
 Session::~Session()
 {
-    // Ensure proper cleanup
-    if (isConnected()) {
-        disconnect();
-    }
+    // Note: Cannot call pure virtual functions from destructor
+    // Subclasses must handle their own cleanup in their destructors
 }
 
 void Session::setSessionName(const QString &name)


### PR DESCRIPTION
- Remove pure virtual function calls from Session destructor (calling pure virtual functions from destructor is undefined behavior)
- Add Q_UNUSED(newName) to suppress unused parameter warning
- TerminalSession properly handles cleanup in its own destructor
- Resolves linker errors and compilation warnings